### PR TITLE
minihack: Improve NetHackWiki integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,8 @@ nle/nethackdir
 outputs/
 latest
 
+nle/minihack/dat/*.json
+
 Session.vim
 
 outputs

--- a/nle/minihack/__init__.py
+++ b/nle/minihack/__init__.py
@@ -5,6 +5,7 @@ from nle.minihack.reward_manager import RewardManager
 from nle.minihack.base import MiniHack
 from nle.minihack.navigation import MiniHackNavigation
 from nle.minihack.skills import MiniHackSkillEnv
+from nle.minihack.wiki import NetHackWiki
 
 import nle.minihack.envs.room  # noqa
 import nle.minihack.envs.keyroom  # noqa
@@ -21,4 +22,5 @@ __all__ = [
     "MiniHackSkillEnv",
     "LevelGenerator",
     "RewardManager",
+    "NetHackWiki",
 ]


### PR DESCRIPTION
Add a method to the base MiniHack class which returns the list of page
contents (in the same format as the list of descriptions) for the
objects in the surrounding tiles of the agent. This uses some NLP
preprocessing to get the text into a format which is more likely to find
the correct wiki page (although there are probably still failured
cases).

The NLP preprocessin is optional - currently it only works if you've
installed the required packages.