### PR TITLE
minihack: Adjust deep explore to always end on staircase

### DIFF
--- a/nle/minihack/base.py
+++ b/nle/minihack/base.py
@@ -209,7 +209,7 @@ class MiniHack(NetHackStaircase):
             if result:
                 return self.StepStatus.TASK_SUCCESSFUL
 
-        # Revert to staircase episode end check (so we always end if we reach
+        # Revert to staircase check (so we always end if we reach it)
         return super()._is_episode_end(observation)
 
     def update(self, des_file):

--- a/nle/minihack/dat/deepexplore10.des
+++ b/nle/minihack/dat/deepexplore10.des
@@ -1,11 +1,9 @@
 LEVEL: "mylevel"
 
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, up
   STAIR: random, down
 }
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, down
   LOOP [4] {
     OBJECT: ('%',"apple"),random
   }

--- a/nle/minihack/dat/deepexplore2.des
+++ b/nle/minihack/dat/deepexplore2.des
@@ -1,11 +1,9 @@
 LEVEL: "mylevel"
 
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, up
   STAIR: random, down
 }
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, down
   LOOP [4] {
     OBJECT: ('%',"apple"),random
   }

--- a/nle/minihack/dat/deepexplore3.des
+++ b/nle/minihack/dat/deepexplore3.des
@@ -1,11 +1,9 @@
 LEVEL: "mylevel"
 
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, up
   STAIR: random, down
 }
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, down
   LOOP [4] {
     OBJECT: ('%',"apple"),random
   }

--- a/nle/minihack/dat/deepexplore5.des
+++ b/nle/minihack/dat/deepexplore5.des
@@ -1,11 +1,9 @@
 LEVEL: "mylevel"
 
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, up
   STAIR: random, down
 }
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, down
   LOOP [4] {
     OBJECT: ('%',"apple"),random
   }

--- a/nle/minihack/dat/deepexplore8.des
+++ b/nle/minihack/dat/deepexplore8.des
@@ -1,11 +1,9 @@
 LEVEL: "mylevel"
 
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, up
   STAIR: random, down
 }
 ROOM: "ordinary" , lit, random, random, random {
-  STAIR: random, down
   LOOP [4] {
     OBJECT: ('%',"apple"),random
   }

--- a/nle/minihack/reward_manager.py
+++ b/nle/minihack/reward_manager.py
@@ -184,7 +184,11 @@ class RewardManager(AbstractRewardManager):
         terminal_required=True,
         terminal_sufficient=False,
     ):
-        msgs = [f"This {name} is delicious"]
+        msgs = [
+            f"This {name} is delicious",
+            "Blecch!  Rotten food!",
+            "last bite of your meal",
+        ]
         if name == "apple":
             msgs.append("Delicious!  Must be a Macintosh!")
             msgs.append("Core dumped.")


### PR DESCRIPTION
For some reason having multiple down staircase results in one of them
not triggering the end of the episode. Hence, we remove the staircase in
the initial room, so that there's only one. The initial room wasn't
going to be the initial room anyway as staircase up has no effect.

Also add some possible messages to the eat task to catch rotten food or
finishing off partially eaten food.