### PR TITLE
minihack-rllib: Add a2/3c configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ latest
 
 nle/minihack/dat/*.json
 Session.vim
+
+wandb

--- a/nle/agent/rllib/config.yaml
+++ b/nle/agent/rllib/config.yaml
@@ -130,6 +130,14 @@ ppo:
   model:
     vf_share_layers: True
 
+a2c:
+  rollout_fragment_length: 32
+  train_batch_size: 256
+  entropy_coeff: 0.0001
+  vf_loss_coeff: 0.5
+  sample_async: False
+
+
 # sac:
 #   learning_starts: 50000
 #   prioritized_replay_beta_annealing_timesteps: 500000

--- a/nle/agent/rllib/train.py
+++ b/nle/agent/rllib/train.py
@@ -10,7 +10,7 @@ from nle.agent.rllib.envs import RLLibNLEEnv  # noqa: F401
 from nle.agent.rllib.models import RLLibNLENetwork  # noqa: F401
 from omegaconf import DictConfig, OmegaConf
 from ray import tune
-from ray.rllib.agents import dqn, impala, ppo
+from ray.rllib.agents import dqn, impala, ppo, a3c
 from ray.tune.integration.wandb import (
     _VALID_ITERABLE_TYPES,
     _VALID_TYPES,
@@ -46,6 +46,7 @@ def get_full_config(cfg: DictConfig) -> DictConfig:
 
 NAME_TO_TRAINER: dict = {
     "impala": (impala, impala.ImpalaTrainer),
+    "a2c": (a3c, a3c.A2CTrainer),
     "dqn": (dqn, dqn.DQNTrainer),
     "ppo": (ppo, ppo.PPOTrainer),
 }


### PR DESCRIPTION
Use A2CTrainer as that's been known to be more robust.

Add wandb to .gitignore