### PR TITLE
minihack: Add mazeexplore task

### DIFF
--- a/nle/minihack/__init__.py
+++ b/nle/minihack/__init__.py
@@ -19,6 +19,7 @@ import nle.minihack.envs.river
 import nle.minihack.envs.hidenseek
 import nle.minihack.envs.lab
 import nle.minihack.envs.deepexplore
+import nle.minihack.envs.exploremaze
 import nle.minihack.envs.skills_simple
 import nle.minihack.envs.skills_wod
 import nle.minihack.envs.skills_levitate

--- a/nle/minihack/dat/exploremazeeasy.des
+++ b/nle/minihack/dat/exploremazeeasy.des
@@ -2,7 +2,7 @@ MAZE: "mylevel",' '
 FLAGS: hardfloor
 GEOMETRY:left,top
 MAP
-|------------
+|-----------|
 |           |
 |           |
 |           |

--- a/nle/minihack/dat/exploremazeeasy.des
+++ b/nle/minihack/dat/exploremazeeasy.des
@@ -1,0 +1,28 @@
+MAZE: "mylevel",' '
+FLAGS: hardfloor
+GEOMETRY:left,top
+MAP
+|------------
+|           |
+|           |
+|           |
+|           |
+|           |
+|           |
+|           |
+|-----.-----|
+|...........|
+|...........|
+-------------
+ENDMAP
+$maze_start = rndcoord(line (0,0),(12,0))
+MAZEWALK:$maze_start,south
+REGION:(1,1,21,21), lit, "ordinary"
+$bottom_room = selection: fillrect(1,9,11,10)
+LOOP [4] {
+    OBJECT: ('%',"apple"),rndcoord($bottom_room)
+}
+STAIR:(01,05,12,07),(0,0,0,0),down
+STAIR:(01,01,12,01),(0,0,0,0),up
+BRANCH:(01,01,12,01),(0,0,0,0)
+TERRAIN: randline (7,1),(7,9),8, '.'

--- a/nle/minihack/dat/exploremazehard.des
+++ b/nle/minihack/dat/exploremazehard.des
@@ -1,0 +1,32 @@
+MAZE: "mylevel",' '
+FLAGS: hardfloor
+GEOMETRY:left,top
+MAP
+|--------------------
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|                   |
+|---------.---------|
+|...................|
+|...................|
+|...................|
+---------------------
+ENDMAP
+$maze_start = rndcoord(line (0,0),(20,0))
+MAZEWALK:$maze_start,south
+REGION:(1,1,21,21), lit, "ordinary"
+$bottom_room = selection: fillrect(1,12,19,14)
+LOOP [7] {
+    OBJECT: ('%',"apple"),rndcoord($bottom_room)
+}
+STAIR:(01,07,20,10),(0,0,0,0),down
+STAIR:(01,01,20,01),(0,0,0,0),up
+BRANCH:(01,01,20,01),(0,0,0,0)
+TERRAIN: randline (11,0),(11,12),10, '.'

--- a/nle/minihack/envs/exploremaze.py
+++ b/nle/minihack/envs/exploremaze.py
@@ -1,0 +1,56 @@
+from gym.envs import registration
+from nle.minihack import MiniHackNavigation
+from nle.minihack.envs.corridor import NAVIGATE_ACTIONS
+from nle.minihack.reward_manager import RewardManager
+from nle.nethack import Command
+
+EAT_ACTION = Command.EAT
+ACTIONS = tuple(list(NAVIGATE_ACTIONS) + [EAT_ACTION])
+
+
+class MiniHackExploreMaze(MiniHackNavigation):
+    """Environment for a memory challenge."""
+
+    def __init__(self, *args, des_file, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 500)
+        kwargs["actions"] = ACTIONS
+        kwargs["allow_all_yn_questions"] = True
+        reward_manager = RewardManager()
+        reward_manager.add_eat_event(
+            "apple",
+            reward=0.5,
+            repeatable=True,
+            terminal_required=False,
+            terminal_sufficient=False,
+        )
+        # Will never be achieved, but insures the environment keeps running
+        reward_manager.add_message_event(
+            ["Mission Complete."], terminal_required=True, terminal_sufficient=True
+        )
+        super().__init__(
+            *args,
+            des_file=des_file,
+            reward_manager=reward_manager,
+            penalty_time=-0.001,  # ensures motivation to finish level quickly
+            **kwargs,
+        )
+
+
+class MiniHackExploreMazeEasy(MiniHackExploreMaze):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, des_file="exploremazeeasy.des", **kwargs)
+
+
+class MiniHackExploreMazeHard(MiniHackExploreMaze):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, des_file="exploremazehard.des", **kwargs)
+
+
+registration.register(
+    id="MiniHack-ExploreMaze-Easy-v0",
+    entry_point="nle.minihack.envs.exploremaze:MiniHackExploreMazeEasy",
+)
+registration.register(
+    id="MiniHack-ExploreMaze-Hard-v0",
+    entry_point="nle.minihack.envs.exploremaze:MiniHackExploreMazeHard",
+)


### PR DESCRIPTION
This is a simpler (hopefully) version of the deep exploration task. The
agent starts at the top of the level, and must navigate a maze to the
exit in the middle of the level. However, there are apples in aroom at
the bottom of the level which provide high reward ife ater. Hence the
optimal strategy is to explore the maze deeply (regardless of whether
the exit has been found) until you find the apple room, and then eat the
apples and exit the level.

We provide an easy and a hard version, with the hard version being
larger and having more apples.