### PR TITLE
agent-rllib: Ensure full hydra config is used

### DIFF
--- a/nle/agent/rllib/config.yaml
+++ b/nle/agent/rllib/config.yaml
@@ -106,12 +106,10 @@ state_counter: none        # none, coordinates
 lr: 0.0002
 gamma: 0.999       # probably a bit better at 0.999, esp with intrinsic reward
 reward_clipping: none    # use none with normalize_reward, else use tim
-normalize_reward: true   # true is reliable across tasks, but false & tim-clip is best on score
 
 # Optimizer settings.
 decay: 0.99        # 0.99 vs 0.9 vs 0.5 seems to make no difference
 momentum: 0        # keep at 0
-epsilon: 0.000001  # do not use 0.01, 1e-6 seems same as 1e-8
 grad_clip: 40
 
 # Algorithm-specific settings. These can override settings above (i.e. learning rate)
@@ -120,6 +118,7 @@ algo: impala  # must match one of the keys below
 impala:
   entropy_coeff: 0.001      # 0.001 is better than 0.0001
   vf_loss_coeff: 0.5
+  epsilon: 0.000001  # do not use 0.01, 1e-6 seems same as 1e-8
 
 dqn:
   double_q: True


### PR DESCRIPTION
Before, there were values in the hydra config (such as `lr`) which were
never being passed to RLlib, which is obviously not good. Also, it was
hard to get visibility in wandb for all the configuration options
passed, as they were too deep in the yaml hierarchy and were OmegaConf
objects rather than plain dicts.

To fix this, we update the default RLlib algorithm config with the hydra
config, and the algo-specific config, and then specific ways the hydra
config should be handled (i.e.  not just directly copying keys to
values, e.g. the model specification and number of actors/cpus).

To ensure RLlib is fine with this, we "create" a new trainer class with
this config as the default one, so we don't receive complaints about
unknown configuration keys.

THis ran for a few iterations without erroring on my computer, and so
should be working correctly, and taking in arguments passed in the
configuration or the command line as we expect.